### PR TITLE
Include curl for healthcheck purpose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV CHPROXY_APP_NAME=${CHPROXY_NAME}
 ENV CHPROXY_BUILD_VERSION=${CHPROXY_VERSION}
 
 RUN apt-get update -y && \
+    apt-get install curl -y && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Thanks to curl, we will be able to specify a healthcheck in docker-compose file: `curl http://localhost:9090/metrics`
This feature allows other containers to depends_on chproxy to be launched.